### PR TITLE
Vis2 spacing changes

### DIFF
--- a/vis2/js/main_vis.js
+++ b/vis2/js/main_vis.js
@@ -49,7 +49,7 @@ function drawVis(data, planetsOnly) {
         .data(planetsData)
 
     // some manual adjustments to spread out the planets a bit more    
-    let planetShifts = {'Mercury': -40, 'Venus': 80, 'Earth': -120, 'Uranus': 35, '136472-Makemake': -20, '136199-Eris': -15}
+    let planetShifts = {'Mercury': -40, 'Venus': 150, 'Earth': -120, 'Mars': 75, 'Uranus': 35, '136472-Makemake': -20, '136199-Eris': -15}
 
     planets.enter().append("circle")
         .attr("class", p => `planet ${p.name.toLowerCase()}`)
@@ -59,7 +59,7 @@ function drawVis(data, planetsOnly) {
             let ypos = (p.semi_major_axis) + HEIGHT / 2 + yval * 20 * Math.min(p.semi_major_axis, 1) + (planetShifts[p.name] || 0)
             return ypos
         })
-        .attr("cx", (p, i) => xScale(p.semi_major_axis) - 30)
+        .attr("cx", (p, i) => xScale(p.semi_major_axis) - 35)
         .attr("r", 8)
 
     // Sun -> planets
@@ -91,11 +91,13 @@ function drawVis(data, planetsOnly) {
     let planetLabels = visSvg.selectAll(".planet-label")
         .data(planetsData)
 
+    let moonlessPlanets = planetsData.filter(p => p.moon_count === 0).map(p => p.name);
+
     planetLabels.enter().append("text")
         .text((p) => p.realName)
         .attr("class", "planet-label")
-        .attr("text-anchor", "end")
-        .attr("x", (p) => +d3.select("#id" + p.name).attr("cx") - 15)
+        .attr("text-anchor", (p) => moonlessPlanets.includes(p.name) ? "start" : "end")
+        .attr("x", (p) => +d3.select("#id" + p.name).attr("cx") + (moonlessPlanets.includes(p.name) ? 12 : -15))
         .attr("y", (p) => +d3.select("#id" + p.name).attr("cy") + 5)
     
     // some silly asteroids / comets -- non-planets with primary orbits

--- a/vis2/js/main_vis.js
+++ b/vis2/js/main_vis.js
@@ -39,7 +39,8 @@ function drawVis(data, planetsOnly) {
     let maxDistance = d3.max(planetsData, p => p.semi_major_axis);
     let minDistance = d3.min(planetsData, p => p.semi_major_axis);
     
-    let xScale = d3.scaleLog()
+    let xScale = d3.scalePow()
+        .exponent(0.7)
         .domain([minDistance, maxDistance])
         .range([120, WIDTH - 100]);
 
@@ -48,17 +49,17 @@ function drawVis(data, planetsOnly) {
         .data(planetsData)
 
     // some manual adjustments to spread out the planets a bit more    
-    let planetShifts = {'Uranus': 35, '136472-Makemake': -20, '136199-Eris': -15}
+    let planetShifts = {'Mercury': -40, 'Venus': 80, 'Earth': -120, 'Uranus': 35, '136472-Makemake': -20, '136199-Eris': -15}
 
     planets.enter().append("circle")
         .attr("class", p => `planet ${p.name.toLowerCase()}`)
         .attr("id", (p) => "id" + p.name)
         .attr("cy", (p, i) => {     // spread out the planets idk
             let yval = i % 2 == 0 ? -i : i
-            let ypos = (p.semi_major_axis) + HEIGHT / 2 + yval * 20 + (planetShifts[p.name] || 0)
+            let ypos = (p.semi_major_axis) + HEIGHT / 2 + yval * 20 * Math.min(p.semi_major_axis, 1) + (planetShifts[p.name] || 0)
             return ypos
         })
-        .attr("cx", (p, i) => xScale(p.semi_major_axis))
+        .attr("cx", (p, i) => xScale(p.semi_major_axis) - 30)
         .attr("r", 8)
 
     // Sun -> planets
@@ -147,7 +148,7 @@ function drawVis(data, planetsOnly) {
             let hostPlanet = data.find(d => d.name === m.orbits_planet)
             
             // Sample from normal distribution, bounded to the right
-            let xOffset = normalRandom(hostPlanet.moon_count + 20, hostPlanet.moon_count * 0.4);
+            let xOffset = normalRandom(hostPlanet.moon_count + 30, hostPlanet.moon_count * 0.4 + 10);
             
             return hostX + xOffset
         })


### PR DESCRIPTION
Changed scaling of solar system from x-axis being linear to being a power scale (x -> x^0.7), to make the scale more manageable for further planets. Moved moon "cloud" from being directly on planets to being on their right, and spaced moons out more when there are more to keep them readable. Moved planet labels from below and to the right to the left, for all planets with moons, to avoid interference.

<img width="931" height="504" alt="image" src="https://github.com/user-attachments/assets/abcc51c5-6fa4-4b7d-a932-b2679e817bfd" />
