### PR TITLE
Vis4/added tooltip, reset button and fix legend

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -460,6 +460,28 @@ button.navBtn {
   pointer-events: none;
 }
 
+#tooltip {
+    position: absolute;     
+    pointer-events: none;     
+    display: none;          
+    background: rgba(38, 48, 81, 0.6);
+    color: white;
+    padding: 15px;
+    font-family: sans-serif;
+    font-size: 13px;
+    line-height: 1.4;            
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+    z-index: 1001;
+
+    width: auto;            
+    min-width: 150px;       
+    max-width: 300px;      
+    margin-top: 0;
+}
+
 .slider-container {
     display: flex;
     flex-direction: column;

--- a/css/styles.css
+++ b/css/styles.css
@@ -423,7 +423,7 @@ button.navBtn {
     z-index: 1000;
 }
 
-#orbit-toggle {
+#orbit-toggle, #reset-btn {
     /* Position and Layout */
     display: block;
     margin: 20px auto;
@@ -447,11 +447,17 @@ button.navBtn {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
 }
 
-#orbit-toggle:hover {
+#orbit-toggle:hover, #reset-btn:hover {
     background: rgba(255, 255, 255, 0.15);
     border-color: #79c8ed; 
     box-shadow: 0 0 15px rgba(121, 200, 237, 0.4);
     transform: translateY(-1px);
+}
+
+#reset-btn:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .slider-container {

--- a/vis4/index.html
+++ b/vis4/index.html
@@ -16,6 +16,7 @@
   <p id="description">Earth's orbit has a low eccentricity, which means it is nearly circular. This is included as a point of comparison.</p>
 
   <div style="position: relative; width: 1100px; margin: 0 auto;">
+    <div id="tooltip"></div>
     <div id="vis4"></div>
     
     <div class="controls-side" style="position: absolute; top: 400px; right: 0px;">

--- a/vis4/index.html
+++ b/vis4/index.html
@@ -12,14 +12,18 @@
 
 <body>
   <h1 class="title">Which bodies have the least circular orbits?</h1>
+  <p id="description">The <strong>eccentricity</strong> of an orbit is a number that measures how "un-circular" the orbit is.</p>
   <p id="description">Earth's orbit has a low eccentricity, which means it is nearly circular. This is included as a point of comparison.</p>
 
   <div style="position: relative; width: 1100px; margin: 0 auto;">
     <div id="vis4"></div>
     
-    <div class="controls-side" style="position: absolute; top: 350px; right: 10px;">
+    <div class="controls-side" style="position: absolute; top: 400px; right: 0px;">
       <button id="orbit-toggle" >
         Start Orbits
+      </button>
+      <button id="reset-btn" disabled>
+        Reset Orbits
       </button>
 
       <div class="slider-container">

--- a/vis4/js/main.js
+++ b/vis4/js/main.js
@@ -124,7 +124,31 @@ function drawOrbitingBodies(group, panel, centralBody, orbiters) {
             .attr("cy", centerY)
             .attr("r", radiusScale(obj.meanRadius))
             .attr("fill", colorScale(obj.eName))
-            .attr("stroke", "#333");
+            .attr("stroke", "#333")
+            .attr("class", "orbiter")
+            .on("mouseover", function(event) {
+                const tooltip = d3.select("#tooltip");
+
+                tooltip.style("display", "block", )
+                    .html(`
+                        <div style="font-size: 1.2rem; font-weight: bold; margin-bottom: 4px; color: #ffdd33;">
+                            ${obj.eName}
+                        </div>
+                        <div style="border-top: 1px solid rgba(255,255,255,0.2); margin-bottom: 4px;"></div>
+                        Orbits: ${obj.orbits}<br/>
+                        Eccentricity: ${obj.eccentricity}<br/>
+                        Mean Radius: ${obj.meanRadius.toLocaleString()} km<br/>
+                        Discovery Date: ${obj.discoveryDate}
+                    `);
+            })
+            .on("mousemove", function(event) {
+                d3.select("#tooltip")
+                    .style("left", (event.pageX - 550) + "px")
+                    .style("top", (event.pageY - 150) + "px");
+            })
+            .on("mouseout", function() {
+                d3.select("#tooltip").style("display", "none");
+            });
 
         // Draw central body once
         if (i === 0) {

--- a/vis4/js/main.js
+++ b/vis4/js/main.js
@@ -135,18 +135,21 @@ function drawOrbitingBodies(group, panel, centralBody, orbiters) {
         // Animation
         // ======================
         const baseSpeed = 0.001 / (Math.sqrt(a) * 0.2);
-        let currentAngle = 0;
+        const state = { angle: 0 };
 
         animationTasks.push((elapsed, deltaTime) => {
+            if (deltaTime === 0) {
+                state.angle = 0;
+            }
 
-            const r = (a * (1 - e ** 2)) / (1 + e * Math.cos(currentAngle));
+            const r = (a * (1 - e ** 2)) / (1 + e * Math.cos(state.angle));
             const angularVelocity = baseSpeed / ((a ** 2) / (r ** 2)) * speedMultiplier;
 
-            currentAngle += angularVelocity * (deltaTime || 16);
+            state.angle += angularVelocity * (deltaTime || 16);
 
             orbiter
-                .attr("cx", centerX + a * Math.cos(currentAngle))
-                .attr("cy", centerY + b * Math.sin(currentAngle));
+                .attr("cx", centerX + a * Math.cos(state.angle))
+                .attr("cy", centerY + b * Math.sin(state.angle));
         });
 
     });
@@ -254,7 +257,7 @@ d3.select("#orbit-toggle").on("click", function(){
 
     if(isAnimating){
 
-        btn.text("Stop Animation");
+        btn.text("Stop Orbits");
         lastTime = performance.now();
 
         mainTimer = d3.timer(()=>{
@@ -266,11 +269,27 @@ d3.select("#orbit-toggle").on("click", function(){
             animationTasks.forEach(task => task(now, deltaTime));
         });
 
+        d3.select("#reset-btn").property("disabled", false);
+
     } else {
 
-        btn.text("Start Animation");
+        btn.text("Start Orbits");
         if(mainTimer) mainTimer.stop();
     }
+});
+
+d3.select("#reset-btn").on("click", function(){
+
+    if (!isAnimating) return;
+    isAnimating = false;
+    d3.select("#orbit-toggle").text("Start Orbits");
+    if(mainTimer) mainTimer.stop();
+    // set all orbiters back to initial positions
+    animationTasks.forEach(task => task(0, 0));
+
+    //grey out button
+    d3.select(this).property("disabled", true);
+
 });
 
 

--- a/vis4/js/main.js
+++ b/vis4/js/main.js
@@ -1,7 +1,7 @@
 // ==========================
 // Constants & Dimensions
 // ==========================
-const width = 1100;
+const width = 1150;
 const height = 800;
 const panelWidth = 800 / 2;
 const panelHeight = height / 2;
@@ -186,7 +186,8 @@ function drawOrbitingBodies(group, panel, centralBody, orbiters) {
 function createLegend(svg, mostEccentric) {
 
     const legend = svg.append("g")
-        .attr("transform", `translate(900,60)`);
+        .attr("transform", `translate(870,60)`)
+        .attr("id", "legend");
 
     legend.append("text")
         .text("Orbiting Bodies")
@@ -225,6 +226,7 @@ d3.csv("data/sol_data.csv").then(data => {
     data.forEach(d => {
         d.eccentricity = +d.eccentricity;
         d.meanRadius = +d.meanRadius;
+        d.discoveryDate = formatSpaceDate(d.discoveryDate);
     });
 
     data.sort((a,b) => b.eccentricity - a.eccentricity);
@@ -269,6 +271,27 @@ d3.csv("data/sol_data.csv").then(data => {
 
     createLegend(svg, mostEccentric);
 });
+
+function formatSpaceDate(dateStr) {
+    if (!dateStr || dateStr === "NA") return "NA";
+
+    // Split "29/4/1998" into [29, 4, 1998]
+    const parts = dateStr.split("/");
+    if (parts.length !== 3) return dateStr;
+
+    const day = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1; // Months are 0-indexed (0 = Jan)
+    const year = parseInt(parts[2], 10);
+
+    const dateObj = new Date(year, month, day);
+
+    // Format to "April 29, 1998"
+    return dateObj.toLocaleDateString('en-US', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric'
+    });
+}
 
 
 // ==========================


### PR DESCRIPTION
A tooltip now pops up when you hover over the orbiting planets.
<img width="584" height="330" alt="image" src="https://github.com/user-attachments/assets/5650e9b5-c2aa-4a5e-9f33-e393ae6742a4" />

A reset button was added. It moves all the planets back to their initial position.
![20260313-2125-04 8729165](https://github.com/user-attachments/assets/5a1d8839-cd3b-4636-8e02-acfb8c638f44)


I also fixed the discovery date formatting from DD/MM/YYYY style to something like January 1, 2000 to make it more readable.