### PR TITLE
shorten volume vis + fix text bug

### DIFF
--- a/vis1/index.html
+++ b/vis1/index.html
@@ -46,8 +46,8 @@
 </div>
 
 <div class="vis2-container" style="margin-top: 50px; text-align: center;">
-  <h1>Timeline of discoveries</h1>
   <svg id="timelineSvg" width="800" height="200"></svg>
+  <!-- <h3>Timeline of discoveries</h3> -->
 </div>
 
 </body>

--- a/vis1/js/complete1.js
+++ b/vis1/js/complete1.js
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const svg = d3.select("#timelineSvg");
     const width = +svg.attr("width");
     const height = +svg.attr("height");
-    const margin = {top: 20, right: 20, bottom: 60, left: 60};
+    const margin = {top: -10, right: 20, bottom: 60, left: 60};
     const plotWidth = width - margin.left - margin.right;
     const plotHeight = height - margin.top - margin.bottom;
 
@@ -73,7 +73,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const plot = svg.append("g")
       .attr("id", "timelineAxes")
-      .attr("transform", `translate(${margin.left},${margin.top})`);
+      .attr("transform", `translate(${margin.left},${margin.top} )`);
+
+    const label = svg.append("text")
+      .attr("x", width / 2)
+      .attr("y", 20)
+      .attr("text-anchor", "middle")
+      .text("Timeline of Discoveries");
 
     const yLine = plotHeight / 2;
 
@@ -135,7 +141,7 @@ function updateTimeline() {
   const pointsGroup = svg
     .append("g")
     .attr("id", "timelinePoints")
-    .attr("transform", `translate(${margin.left},${margin.top})`);
+    .attr("transform", `translate(${margin.left}, 5)`);
 
   const centuries = ["Antiquity", "1600s", "1700s", "1800s", "1900s", "2000s"];
   const xScale = d3.scalePoint()
@@ -227,7 +233,7 @@ function updateTimeline() {
 
   // --- Circle Packing ---
   function drawPackedSun(data, containerName = "Sun") {
-    const width = 500;
+    const width = 600;
     const height = 500;
     const centerX = width / 2;
     const centerY = height / 2;

--- a/vis1/js/complete1.js
+++ b/vis1/js/complete1.js
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const svg = d3.select("#timelineSvg");
     const width = +svg.attr("width");
     const height = +svg.attr("height");
-    const margin = {top: -10, right: 20, bottom: 60, left: 60};
+    const margin = {top: -90, right: 20, bottom: 60, left: 60};
     const plotWidth = width - margin.left - margin.right;
     const plotHeight = height - margin.top - margin.bottom;
 
@@ -77,7 +77,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const label = svg.append("text")
       .attr("x", width / 2)
-      .attr("y", 20)
+      .attr("y", 90)
       .attr("text-anchor", "middle")
       .text("Timeline of Discoveries");
 
@@ -129,7 +129,7 @@ function updateTimeline() {
   const svg = d3.select("#timelineSvg");
   const width = +svg.attr("width");
   const height = +svg.attr("height");
-  const margin = { top: 20, right: 20, bottom: 60, left: 60 };
+  const margin = { top: -90, right: 20, bottom: 60, left: 60 };
   const plotWidth = width - margin.left - margin.right;
   const plotHeight = height - margin.top - margin.bottom;
   const yLine = plotHeight / 2;
@@ -141,7 +141,7 @@ function updateTimeline() {
   const pointsGroup = svg
     .append("g")
     .attr("id", "timelinePoints")
-    .attr("transform", `translate(${margin.left}, 5)`);
+    .attr("transform", `translate(${margin.left}, ${margin.top})`);
 
   const centuries = ["Antiquity", "1600s", "1700s", "1800s", "1900s", "2000s"];
   const xScale = d3.scalePoint()


### PR DESCRIPTION
shortens volume vis and also fixes small bug where svg was too narrow and text was being cut off sometimes

before: 
<img width="920" height="711" alt="image" src="https://github.com/user-attachments/assets/ca3f8ec9-0a18-47c8-997d-d1293abcdfa8" />


after: 
<img width="1071" height="708" alt="image" src="https://github.com/user-attachments/assets/e9d5a6af-597a-4361-9871-84dae023c934" />

